### PR TITLE
Revert "Bump h2 from 1.3.176 to 2.2.220 in /SpringCloud/service-discovery/user-service"

### DIFF
--- a/SpringCloud/service-discovery/user-service/pom.xml
+++ b/SpringCloud/service-discovery/user-service/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.2.220</version>
+            <version>1.3.176</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Reverts KyeonghoYoo/Study#9

- 해당 h2 데이베이스의 버전은 의도적으로 낮은 버전을 사용함.
- 프로덕트에 쓰일 버전이 아니기 때문에 학습의 편의를 위해 사용한 이유가 있음.
    - 최신 버전의 h2 데이터베이스의 보안상 이유에서 디비 자동 생성 기능을 막았음.
    - 해당 '자동 생성' 기능을 활용해 빠른 학습 진행을 위해 의도적으로 낮은 버전을 사용함.